### PR TITLE
feat: added warnlog

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ const Utils = require('./utils')
  * @property {any[]} [secrets=[]] Secrets to hide
  * @property {noPerm} [noPerm] Executed when command runned by not allowed user
  * @property {boolean} [disableAttachmentExecution=false] Disable attachment execution.
+ * @property {boolean} [warnlog=true] Send warn log when command runned by allowed user
  */
 
 /**
@@ -35,7 +36,7 @@ module.exports = class Dokdo {
    * @param {Discord.Client} client Discord Client
    * @param {DokdoOptions} options Dokdo Options
    */
-  constructor (client, { aliases = ['dokdo', 'dok'], owners = null, prefix, secrets = [], noPerm, disableAttachmentExecution = false } = {}) {
+  constructor (client, { aliases = ['dokdo', 'dok'], owners = null, prefix, secrets = [], noPerm, disableAttachmentExecution = false, warnlog = false } = {}) {
     if (!(client instanceof Discord.Client)) throw new Error('Invalid `client`. `client` parameter is required.')
     // if (!this.options || typeof options !== 'object') throw new Error('Invliad `options`. `options` parameter is required.')
     this.owners = owners
@@ -53,7 +54,7 @@ module.exports = class Dokdo {
 
     this.client = client
     this.process = []
-    this.options = { prefix, aliases, secrets, noPerm, disableAttachmentExecution }
+    this.options = { prefix, aliases, secrets, noPerm, disableAttachmentExecution, warnlog }
     if (!this.options.secrets || !Array.isArray(this.options.secrets)) this.options.secrets = []
     if (!this.options.aliases) this.options.aliases = ['dokdo', 'dok']
   }
@@ -91,6 +92,7 @@ module.exports = class Dokdo {
       if (this.options.noPerm) return this.options.noPerm(message)
       else return
     }
+    if (this.options.warnlog) console.warn(`[dokdo/${message.data.type}] ${message.author.tag}(${message.author.id}) tried emit Command: ${message.data.args}`)
 
     if (!message.data.type) return Commands.main(message, this)
     switch (message.data.type) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Emit command is a very sensitive.
so Add warn log when command runned by allowed user and option.

this option Default value is false
I recommand it set true in option.
But it can be breaking change.
so now Default value is false.

**when it enable when tried command, it printed:**  

[dokdo/{ Type }] { UserTag }({ UserID }) tried emit Command: { args }  
> eg) `[dokdo/js] 모메MoMe#0500(236696896658341888) tried emit Command: console.log('hello world')`

**Status**

- [x] Code changes have been tested.

**Semantic versioning classification:**

- [x] This PR includes new feature, methods or parameters
- [ ] This PR includes breaking changes (feature, methods, parameters removed or renamed)
- [ ] This PR **only** includes non-code(typo, documentation etc.) changes
