### PR TITLE
fix: replace qs to URLSearchParams

### DIFF
--- a/src/utils/djsDocs.js
+++ b/src/utils/djsDocs.js
@@ -1,4 +1,3 @@
-const qs = require('querystring')
 const fetch = require('node-fetch')
 const Discord = require('discord.js')
 
@@ -8,8 +7,8 @@ module.exports.source = version => {
 }
 
 module.exports.docs = async (q) => {
-  const queryString = qs.stringify({ src: this.source(Discord.version), q })
-  const res = await fetch(`https://djsdocs.sorta.moe/v2/embed?${queryString}`)
+  const params = new URLSearchParams({ src: this.source(Discord.version), q })
+  const res = await fetch(`https://djsdocs.sorta.moe/v2/embed?${params}`)
   const embed = await res.json()
   console.log(embed)
   if (!embed) return 'Nothing found'


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The querystring API is considered Legacy.
So replace URLSearchParams

**Status**

- [x] Code changes have been tested.

**Semantic versioning classification:**

- [ ] This PR includes new feature, methods or parameters
  - [ ] This PR includes breaking changes (feature, methods, parameters removed or renamed)
- [ ] This PR **only** includes non-code(typo, documentation etc.) changes
