### PR TITLE
chore(djsdocs): force fetch from source

### DIFF
--- a/src/utils/djsDocs.js
+++ b/src/utils/djsDocs.js
@@ -11,7 +11,7 @@ module.exports.source = version => {
  * @returns {Promise<string|Discord.MessageOptions>}
  */
 module.exports.docs = async (q) => {
-  const params = new URLSearchParams({ src: this.source(Discord.version), q })
+  const params = new URLSearchParams({ force: true, src: this.source(Discord.version), q })
   const res = await fetch(`https://djsdocs.sorta.moe/v2/embed?${params}`)
   const embed = await res.json()
   console.log(embed)


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
See: https://github.com/TeeSeal/discord.js-docs-api
seems main branch cached, so it will force fetch from source

<img src="https://user-images.githubusercontent.com/50764666/131067475-0e1d372a-d74d-474f-9738-472597cc3e12.jpg" height=300 />

> without `force` query

<img src="https://user-images.githubusercontent.com/50764666/131067423-d6c1ae92-dc2b-49db-a791-024331b52555.jpg" height=300 />

> with `force` query

**Status**

- [x] Code changes have been tested.

**Semantic versioning classification:**

- [x] This PR includes new feature, methods or parameters
  - [ ] This PR includes breaking changes (feature, methods, parameters removed or renamed)
- [ ] This PR **only** includes non-code(typo, documentation etc.) changes
