### PR TITLE
feat: isOwner option

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -16,6 +16,7 @@ declare module 'dokdo' {
     secrets?: any[]
     globalVariable?: Record<string, any>
     noPerm(message: Discord.Message): any|Promise<any>
+    isOwner?: (user: Discord.User) => boolean|Promise<boolean>
   }
 
   export class ProcessManager {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

isOwner 옵션을 추가했습니다.

타입: `(user: Discord.User) => boolean|Promise<boolean>`

owners 리스트에 명령어를 사용한 유저가 없을 경우에 호출됩니다.

true를 반환할 시 dokdo 명령어를 사용할 수 있게 됩니다

**Status**

- [x] Code changes have been tested.

**Semantic versioning classification:**

- [x] This PR includes new feature, methods or parameters
  - [ ] This PR includes breaking changes (feature, methods, parameters removed or renamed)
- [ ] This PR **only** includes non-code(typo, documentation etc.) changes
