### PR TITLE
feat: indiciate internal sharding

### DIFF
--- a/src/commands/main.ts
+++ b/src/commands/main.ts
@@ -28,7 +28,13 @@ export async function main (message: Context, parent: Client): Promise<void> {
         out.reduce((prev, val) => prev + val, 0)
       })
     summary += `Running on PID ${process.pid} for this client, and running on PID ${process.ppid} for the parent process.\n\nThis bot is sharded in ${parent.client.shard.count} shard(s) and running in ${guilds} guild(s).\nCan see ${cache} in this client.`
-  } else { summary += `Running on PID ${process.pid}\n\nThis bot is not sharded and can see ${cache}.` }
+  } else {
+    if (Array.isArray(parent.client.options.shards) && parent.client.options.shards.length > 1) {
+      summary += `Running on PID ${process.pid}\n\nThis bot is sharded internally in ${parent.client.options.shardCount} shard(s) and can see ${cache}.`
+    } else {
+      summary += `Running on PID ${process.pid}\n\nThis bot is not sharded and can see ${cache}.`
+    }
+  }
 
   summary +=
     '\n' +


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR introduces indication of internal sharing.

Note that this does not take into account specifying shard id(s) (to shard without ShardingManager).
That is, if the process(or a Client) is running a shard which id is 3, Dokdo will not show any information about shard the client is running (as same as before)

I state this PR as draft as I am not sure if I should consider such cases.

**Status**

- [ ] Code changes have been tested.

**Semantic versioning classification:**

- [ ] This PR includes new feature, methods or parameters
  - [ ] This PR includes breaking changes (feature, methods, parameters removed or renamed)
- [ ] This PR **only** includes non-code(typo, documentation etc.) changes
